### PR TITLE
DWN-41034 : upgrade JSoup to 1.15.3

### DIFF
--- a/openid-connect-common/src/main/java/org/mitre/openid/connect/web/UserInfoInterceptor.java
+++ b/openid-connect-common/src/main/java/org/mitre/openid/connect/web/UserInfoInterceptor.java
@@ -26,7 +26,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.jsoup.Jsoup;
-import org.jsoup.safety.Whitelist;
+import org.jsoup.safety.Safelist;
 import org.mitre.openid.connect.model.Address;
 import org.mitre.openid.connect.model.OIDCAuthenticationToken;
 import org.mitre.openid.connect.model.UserInfo;
@@ -54,7 +54,7 @@ import com.google.gson.JsonSerializer;
  */
 public class UserInfoInterceptor extends HandlerInterceptorAdapter {
 
-	private final Whitelist whitelist = Whitelist.none();
+	private final Safelist safelist = Safelist.none();
 
 	private Gson gson = new GsonBuilder()
 			.registerTypeHierarchyAdapter(GrantedAuthority.class, new JsonSerializer<GrantedAuthority>() {
@@ -145,7 +145,7 @@ public class UserInfoInterceptor extends HandlerInterceptorAdapter {
 	
 	private String sanitise(String elementToClean) {
 		if (elementToClean != null) {
-			return Jsoup.clean(elementToClean, whitelist);
+			return Jsoup.clean(elementToClean, safelist);
 		}
 		return null;
 	}

--- a/pom.xml
+++ b/pom.xml
@@ -613,7 +613,7 @@
 			<dependency>
 				<groupId>org.jsoup</groupId>
 				<artifactId>jsoup</artifactId>
-				<version>1.14.2</version>
+				<version>1.15.3</version>
 			</dependency>
 			<dependency>
 				<groupId>commons-codec</groupId>


### PR DESCRIPTION
Related reviews:
https://github.com/gresham-computing/openid-connect-server/pull/30
https://github.com/gresham-computing/clareti-auth/pull/198
https://github.com/gresham-computing/ctc/pull/1268

There are also branches for 
Common Security - https://github.com/gresham-computing/clareti-common-security/tree/DWN-41034_jsoup
MF Data - https://github.com/gresham-computing/clareti-market-facing-data/tree/DWN-41034_jsoup
Cash Proof - https://github.com/gresham-computing/clareti-cashproof/tree/DWN-41034_jsoup
but these only point branch versions and do not need direct review